### PR TITLE
add compatibility date

### DIFF
--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -2,5 +2,6 @@ import { defineNitroConfig } from "nitropack/config"
 
 //https://nitro.unjs.io/config
 export default defineNitroConfig({
-  srcDir: "server"
+  srcDir: "server",
+  compatibilityDate: "2025-04-08"
 });


### PR DESCRIPTION
Hi 👋 ! I work at StackBlitz and I noticed that when opening the nitro starter, it doesn't auto start. The reason is that it asks the user first to se the `compatibiltyDate`.

![image](https://github.com/user-attachments/assets/036267fc-0c9f-46f0-bc19-ee3839f9a5d7)

This PR adds that to make sure that the starter auto starts and doesn't wait for the user to accept something in the terminal.