### PR TITLE
specify encoding of index page

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,6 +3,7 @@ import { eventHandler } from "h3"
 // Learn more: https://nitro.build/guide/routing
 export default eventHandler((event) => {
   return `
+      <meta charset="utf-8">
       <h1>This is your brand new Nitro project 🚀 </h1>
       <p>Get started by editing the <code>server/routes/index.ts</code> file.</p>
       <p>Learn more from 📖 <a href="https://nitro.build/guide" target="_blank">Nitro Documentation</a></p>


### PR DESCRIPTION
emoji may not show up properly (in the screenshot) without a `<meta>` tag. 

<img width="1170" height="231" alt="screenshot before PR" src="https://github.com/user-attachments/assets/ddb81de5-f2e5-4889-b539-a8c6be11d959" />
